### PR TITLE
Fix | Swap publish and subscribe operations in async API channel handling

### DIFF
--- a/parser.go
+++ b/parser.go
@@ -1205,11 +1205,11 @@ func addAsyncAPIOperations(parser *Parser, asyncAPIScope *AsyncScope) {
 		channel := parser.asyncAPI.Channels[operation.channel]
 
 		if operation.action == Receive {
-			channel.Subscribe = &operation.Operation
+			channel.Publish = &operation.Operation
 		}
 
 		if operation.action == Send {
-			channel.Publish = &operation.Operation
+			channel.Subscribe = &operation.Operation
 		}
 
 		parser.asyncAPI.Channels[operation.channel] = channel


### PR DESCRIPTION
**Describe the PR**
* Swap publish and subscribe operations in async API channel handling. According to the docs (not so intuitive tho):

<img width="688" alt="image" src="https://github.com/user-attachments/assets/b0da3e2d-1c23-47ef-92d4-7c65aa6f2bda" />

