### PR TITLE
Feat | Avoid error when attribute unknown

### DIFF
--- a/async_operation.go
+++ b/async_operation.go
@@ -86,7 +86,8 @@ func (asyncScope *AsyncScope) ParseAsyncAPIComment(funcName *string, comment str
 
 	handler, exists := AttributeHandler[Attribute(lowerAttribute)]
 	if !exists {
-		return fmt.Errorf("unknown attribute '%s' in comment '%s'", attribute, comment)
+		log.Printf("unknown attribute '%s' in comment '%s', skipping...", attribute, comment)
+		return nil
 	}
 
 	return handler(asyncScope, funcName, lineRemainder, astFile)

--- a/async_operation_test.go
+++ b/async_operation_test.go
@@ -198,12 +198,11 @@ func TestReplaceStringInJSON(t *testing.T) {
 
 func TestInvalidCommentAttr(t *testing.T) {
 	t.Parallel()
-	t.Run("returns error if unknown attr", func(t *testing.T) {
+	t.Run("does not return error if unknown attr", func(t *testing.T) {
 		asyncScope := NewAsyncScope(nil)
 		comment := "@unknownAttr somevalue"
 
 		err := asyncScope.ParseAsyncAPIComment(nil, comment, nil)
-		assert.Error(t, err)
-		assert.Equal(t, "unknown attribute '@unknownAttr' in comment '@unknownAttr somevalue'", err.Error())
+		assert.NoError(t, err)
 	})
 }


### PR DESCRIPTION
**Describe the PR**
* When async scope comment attribute is unknown, does not return an error anymore. Instead, log the value and skip the comment
