### PR TITLE
Use shorter names for schemas

### DIFF
--- a/parser.go
+++ b/parser.go
@@ -207,6 +207,9 @@ type Parser struct {
 
 	// use new openAPI version
 	openAPIVersion bool
+
+	// use the definition hash to resolve conflicts
+	definitions map[string]uint
 }
 
 // FieldParserFactory create FieldParser.
@@ -285,6 +288,7 @@ func New(options ...func(*Parser)) *Parser {
 				Schemas: make(map[string]map[string]interface{}),
 			},
 		},
+		definitions: make(map[string]uint),
 	}
 
 	for _, option := range options {

--- a/parser.go
+++ b/parser.go
@@ -208,8 +208,8 @@ type Parser struct {
 	// use new openAPI version
 	openAPIVersion bool
 
-	// use the definition hash to resolve conflicts
-	definitions map[string]uint
+	// use the typeNames hash to resolve conflicts
+	typeNames map[string]uint
 }
 
 // FieldParserFactory create FieldParser.
@@ -288,7 +288,7 @@ func New(options ...func(*Parser)) *Parser {
 				Schemas: make(map[string]map[string]interface{}),
 			},
 		},
-		definitions: make(map[string]uint),
+		typeNames: make(map[string]uint),
 	}
 
 	for _, option := range options {

--- a/parserv3.go
+++ b/parserv3.go
@@ -1119,11 +1119,11 @@ func (p *Parser) getDefinitionNameV3(typeName string, packagePath string) string
 
 	// Reconcile conflicting names by adding a number suffix if necessary.
 	// Example: "Foo" -> "Foo_1", "Foo_1" -> "Foo_2"
-	if count, ok := p.definitions[typeName]; ok {
-		p.definitions[typeName]++
+	if count, ok := p.typeNames[typeName]; ok {
+		p.typeNames[typeName]++
 		return fmt.Sprintf("%s_%d", typeName, count+1)
 	}
 
-	p.definitions[typeName] = 1
+	p.typeNames[typeName] = 1
 	return typeName
 }

--- a/parserv3.go
+++ b/parserv3.go
@@ -1117,7 +1117,8 @@ func (p *Parser) getDefinitionNameV3(typeName string, packagePath string) string
 	typeName = strings.TrimSuffix(typeName, "_")
 	typeName = multipleUnderscores.ReplaceAllString(typeName, "_")
 
-	// Look for name collisions.
+	// Reconcile conflicting names by adding a number suffix if necessary.
+	// Example: "Foo" -> "Foo_1", "Foo_1" -> "Foo_2"
 	if count, ok := p.definitions[typeName]; ok {
 		p.definitions[typeName]++
 		return fmt.Sprintf("%s_%d", typeName, count+1)

--- a/parserv3.go
+++ b/parserv3.go
@@ -703,7 +703,7 @@ func (p *Parser) ParseDefinitionV3(typeSpecDef *TypeSpecDef) (*SchemaV3, error) 
 		p.debug.Printf("Skipping '%s', recursion detected.", typeName)
 
 		return &SchemaV3{
-				Name:    typeName,
+				Name:    p.getDefinitionNameV3(typeName, typeSpecDef.PkgPath),
 				PkgPath: typeSpecDef.PkgPath,
 				Schema:  PrimitiveSchemaV3(OBJECT).Spec,
 			},
@@ -750,7 +750,7 @@ func (p *Parser) ParseDefinitionV3(typeSpecDef *TypeSpecDef) (*SchemaV3, error) 
 	}
 
 	sch := SchemaV3{
-		Name:    schemaName,
+		Name:    p.getDefinitionNameV3(schemaName, typeSpecDef.PkgPath),
 		PkgPath: typeSpecDef.PkgPath,
 		Schema:  definition.Spec,
 	}
@@ -1090,4 +1090,38 @@ func (p *Parser) GetSchemaTypePathV3(schema *spec.RefOrSpec[spec.Schema], depth 
 func (p *Parser) getSchemaByRef(ref *spec.Ref) *spec.Schema {
 	searchString := strings.ReplaceAll(ref.Ref, "#/components/schemas/", "")
 	return p.openAPI.Components.Spec.Schemas[searchString].Spec
+}
+
+func (p *Parser) getDefinitionNameV3(typeName string, packagePath string) string {
+	// Short circuit if typeName is empty
+	if typeName == "" {
+		return ""
+	}
+
+	// Get the last part of the package path
+	parts := strings.Split(packagePath, "/")
+	for i := len(parts) - 1; i > 0; i-- {
+		oldPackageName := strings.Join(parts[:i], "_")
+		oldPackageName = strings.ReplaceAll(oldPackageName, ".", "_")
+
+		if strings.Contains(typeName, oldPackageName) {
+			typeName = strings.Replace(typeName, oldPackageName, "", 1)
+			break
+		}
+	}
+
+	// Remove unneeded separators.
+	typeName = strings.TrimPrefix(typeName, "_")
+	typeName = strings.TrimSuffix(typeName, "_")
+	re := regexp.MustCompile(`_+`)
+	typeName = re.ReplaceAllString(typeName, "_")
+
+	// Look for name collisions.
+	if count, ok := p.definitions[typeName]; ok {
+		p.definitions[typeName]++
+		return fmt.Sprintf("%s_%d", typeName, count+1)
+	}
+
+	p.definitions[typeName] = 1
+	return typeName
 }

--- a/parserv3.go
+++ b/parserv3.go
@@ -1092,6 +1092,8 @@ func (p *Parser) getSchemaByRef(ref *spec.Ref) *spec.Schema {
 	return p.openAPI.Components.Spec.Schemas[searchString].Spec
 }
 
+var multipleUnderscores = regexp.MustCompile(`_+`)
+
 func (p *Parser) getDefinitionNameV3(typeName string, packagePath string) string {
 	// Short circuit if typeName is empty
 	if typeName == "" {
@@ -1113,8 +1115,7 @@ func (p *Parser) getDefinitionNameV3(typeName string, packagePath string) string
 	// Remove unneeded separators.
 	typeName = strings.TrimPrefix(typeName, "_")
 	typeName = strings.TrimSuffix(typeName, "_")
-	re := regexp.MustCompile(`_+`)
-	typeName = re.ReplaceAllString(typeName, "_")
+	typeName = multipleUnderscores.ReplaceAllString(typeName, "_")
 
 	// Look for name collisions.
 	if count, ok := p.definitions[typeName]; ok {

--- a/parserv3_test.go
+++ b/parserv3_test.go
@@ -520,7 +520,7 @@ func TestParseTypeAlias(t *testing.T) {
 func TestGetDefinitionNameV3(t *testing.T) {
 	t.Run("Test name collision", func(t *testing.T) {
 		p := &Parser{
-			definitions: make(map[string]uint),
+			typeNames: make(map[string]uint),
 		}
 		t1 := p.getDefinitionNameV3("test", "test")
 		t2 := p.getDefinitionNameV3("test", "test")
@@ -565,7 +565,7 @@ func TestGetDefinitionNameV3(t *testing.T) {
 	for _, test := range tests {
 		t.Run(test.typeName, func(t *testing.T) {
 			p := &Parser{
-				definitions: make(map[string]uint),
+				typeNames: make(map[string]uint),
 			}
 			result := p.getDefinitionNameV3(test.typeName, test.packagePath)
 			assert.Equal(t, test.expected, result)

--- a/parserv3_test.go
+++ b/parserv3_test.go
@@ -526,7 +526,7 @@ func TestGetDefinitionNameV3(t *testing.T) {
 		t2 := p.getDefinitionNameV3("test", "test")
 
 		assert.NotEqual(t, t1, t2, "should be different")
-		assert.True(t, strings.HasPrefix(t2, t1), "should be prefixed with %s", t1)
+		assert.Truef(t, strings.HasPrefix(t2, t1), "should be prefixed with %s", t1)
 
 	})
 

--- a/parserv3_test.go
+++ b/parserv3_test.go
@@ -5,6 +5,7 @@ import (
 	"go/ast"
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -375,7 +376,7 @@ func TestParseSimpleApiV3(t *testing.T) {
 	path = paths["/FormData"].Spec.Spec.Post.Spec
 	assert.NotNil(t, path)
 	assert.NotNil(t, path.RequestBody)
-	//TODO add asserts
+	// TODO add asserts
 
 	t.Run("Test parse struct oneOf", func(t *testing.T) {
 		t.Parallel()
@@ -514,4 +515,60 @@ func TestParseTypeAlias(t *testing.T) {
 	require.NoError(t, err)
 
 	assert.JSONEq(t, string(expected), string(result))
+}
+
+func TestGetDefinitionNameV3(t *testing.T) {
+	t.Run("Test name collision", func(t *testing.T) {
+		p := &Parser{
+			definitions: make(map[string]uint),
+		}
+		t1 := p.getDefinitionNameV3("test", "test")
+		t2 := p.getDefinitionNameV3("test", "test")
+
+		assert.NotEqual(t, t1, t2, "should be different")
+		assert.True(t, strings.HasPrefix(t2, t1), "should be prefixed with %s", t1)
+
+	})
+
+	tests := []struct {
+		typeName    string
+		packagePath string
+		expected    string
+	}{
+		{
+			typeName:    "",
+			packagePath: "",
+			expected:    "",
+		},
+		{
+			typeName:    "string",
+			packagePath: "",
+			expected:    "string",
+		},
+		{
+			typeName:    "rest.encodedFilter",
+			packagePath: "github.com/yalochat/customer-profiles-api/services/audiences/internal/handlers/rest",
+			expected:    "rest.encodedFilter",
+		},
+		{
+			typeName:    "github_com_yalochat_customer-profiles-api_services_audiences_pkg_contact.Contact",
+			packagePath: "github.com/yalochat/customer-profiles-api/services/audiences/pkg/contact",
+			expected:    "contact.Contact",
+		},
+		{
+			typeName:    "rest.Response-array_github_com_yalochat_customer-profiles-api_services_audiences_pkg_contact_Audience",
+			packagePath: "github.com/yalochat/customer-profiles-api/services/audiences/internal/handlers/rest",
+			expected:    "rest.Response-array_pkg_contact_Audience",
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.typeName, func(t *testing.T) {
+			p := &Parser{
+				definitions: make(map[string]uint),
+			}
+			result := p.getDefinitionNameV3(test.typeName, test.packagePath)
+			assert.Equal(t, test.expected, result)
+		})
+	}
 }


### PR DESCRIPTION
This pull request introduces a mechanism to handle name collisions in schema definitions by adding a new `definitions` map to the `Parser` struct and implementing the `getDefinitionNameV3` method. It also includes updates to the `ParseDefinitionV3` method to utilize this new functionality and adds corresponding unit tests for validation.

### Enhancements to schema name handling:

* [`parser.go`](diffhunk://#diff-83eb8e32639d01cf443d6d8bde24c1c8be78766090d8c5f8586c36250cfedca6R210-R212): Added a `definitions` map to the `Parser` struct to track and resolve name collisions in schema definitions. This ensures unique names for schemas. 
* [`parserv3.go`](diffhunk://#diff-2b4e7cf48d125d91e66cbca4658b1828194f4e787902694aeea0f8328c555468L706-R706): Introduced the `getDefinitionNameV3` method to generate unique schema names by resolving package path conflicts and handling name collisions. Updated the `ParseDefinitionV3` method to use this new function for schema name resolution.

### Unit tests for new functionality:

* [`parserv3_test.go`](diffhunk://#diff-d4a6e98bf4a857d4a8ee3cdaeae97ff7ca1eb496602955dde793a4889ff312fdR519-R574): Added a comprehensive test suite for the `getDefinitionNameV3` method, covering scenarios such as name collisions, empty type names, and package path conflicts.
* [`parserv3_test.go`](diffhunk://#diff-d4a6e98bf4a857d4a8ee3cdaeae97ff7ca1eb496602955dde793a4889ff312fdR8): Included the `strings` package to support test implementation.