### PR TITLE
Forbid duplicated values for enums

### DIFF
--- a/async_operation.go
+++ b/async_operation.go
@@ -22,25 +22,25 @@ const (
 )
 
 const (
-	serverAttr Attribute = "@server"
-	channelAttr Attribute = "@channel"
+	serverAttr    Attribute = "@server"
+	channelAttr   Attribute = "@channel"
 	operationAttr Attribute = "@operation"
 )
 
 const (
-	openAPISchemaPrefix = "#/definitions/"
+	openAPISchemaPrefix  = "#/definitions/"
 	asyncAPISchemaPrefix = "#/components/schemas/"
 )
 
 type AsyncScope struct {
-	parser *Parser
-	servers map[string]*spec.ServersAdditionalProperties
-	channels map[string]*spec.ChannelItem
+	parser     *Parser
+	servers    map[string]*spec.ServersAdditionalProperties
+	channels   map[string]*spec.ChannelItem
 	operations map[string]*OperationWithChannel
 }
 
 type OperationWithChannel struct {
-	action OperationAction
+	action  OperationAction
 	channel string
 	spec.Operation
 }
@@ -52,19 +52,19 @@ func NewAsyncScope(parser *Parser) *AsyncScope {
 	}
 
 	asyncOperation := &AsyncScope{
-		parser:           parser,
-		servers:          make(map[string]*spec.ServersAdditionalProperties),
-		channels:         make(map[string]*spec.ChannelItem),
-		operations:       make(map[string]*OperationWithChannel),
+		parser:     parser,
+		servers:    make(map[string]*spec.ServersAdditionalProperties),
+		channels:   make(map[string]*spec.ChannelItem),
+		operations: make(map[string]*OperationWithChannel),
 	}
 
 	return asyncOperation
 }
 
 // AttributeHandler is a map of attribute to the function that handles the attribute.
-var AttributeHandler = map[Attribute]func(*AsyncScope, *string, string, *ast.File) error {
-	serverAttr:  (*AsyncScope).ParseServerComment,
-	channelAttr: (*AsyncScope).ParseChannelComment,
+var AttributeHandler = map[Attribute]func(*AsyncScope, *string, string, *ast.File) error{
+	serverAttr:    (*AsyncScope).ParseServerComment,
+	channelAttr:   (*AsyncScope).ParseChannelComment,
 	operationAttr: (*AsyncScope).ParseOperationComment,
 }
 
@@ -78,7 +78,7 @@ func (asyncScope *AsyncScope) ParseAsyncAPIComment(funcName *string, comment str
 	fields := FieldsByAnySpace(commentLine, 2)
 	attribute := fields[0]
 	lowerAttribute := strings.ToLower(attribute)
-	
+
 	var lineRemainder string
 	if len(fields) > 1 {
 		lineRemainder = fields[1]
@@ -108,7 +108,7 @@ func (asyncScope *AsyncScope) ParseServerComment(funcName *string, commentLine s
 
 	asyncScope.servers[serverName] = &spec.ServersAdditionalProperties{
 		Server: &spec.Server{
-			URL: host,
+			URL:      host,
 			Protocol: protocol,
 		},
 	}
@@ -124,13 +124,13 @@ func (asyncScope *AsyncScope) ParseChannelComment(funcName *string, commentLine 
 	if len(matches) < 4 {
 		return fmt.Errorf("missing required param comment parameters \"%s\"", commentLine)
 	}
-	
+
 	channelName := matches[1]
 	server := matches[2]
 	description := matches[3]
 
 	asyncScope.channels[channelName] = &spec.ChannelItem{
-		Servers: []string{server},
+		Servers:     []string{server},
 		Description: description,
 	}
 
@@ -138,7 +138,6 @@ func (asyncScope *AsyncScope) ParseChannelComment(funcName *string, commentLine 
 }
 
 var operationCommentPattern = regexp.MustCompile(`(\S+)\s+(\S+)\s+(\S+)\s*(.*)?`)
-
 
 // @operation {operationID} {action} {channel} {message}
 // @operation {action} {channel} {message}

--- a/async_operation_test.go
+++ b/async_operation_test.go
@@ -138,7 +138,7 @@ func TestParseOperationComment(t *testing.T) {
 			name:        "parses a valid @operation comment - funcName used as operationID",
 			comment:     `@operation send topic1 model.OrderRow`,
 			expectedErr: "",
-			funcName: 	&funcNameExample,
+			funcName:    &funcNameExample,
 			assertFunc: func(t *testing.T, err error, asyncScope *AsyncScope) {
 				assert.Contains(t, asyncScope.operations, "myOperation")
 				assert.Equal(t, Send, asyncScope.operations["myOperation"].action)

--- a/field_parser.go
+++ b/field_parser.go
@@ -587,6 +587,13 @@ func parseEnumTags(enumTag string, field *structField) error {
 			return err
 		}
 
+		for _, e := range field.enums {
+			if reflect.DeepEqual(e, value) {
+				// skip duplicate enum value
+				return nil
+			}
+		}
+
 		field.enums = append(field.enums, value)
 	}
 

--- a/field_parser.go
+++ b/field_parser.go
@@ -611,11 +611,16 @@ func parseEnumTags(enumTag string, field *structField) error {
 			return err
 		}
 
+		foundDuplicate := false
 		for _, e := range field.enums {
 			if enumValueEqual(e, value) {
-				// skip duplicate enum value
+				foundDuplicate = true
 				continue
 			}
+		}
+
+		if foundDuplicate {
+			continue
 		}
 
 		field.enums = append(field.enums, value)

--- a/field_parser.go
+++ b/field_parser.go
@@ -13,7 +13,7 @@ import (
 	"github.com/go-openapi/spec"
 )
 
-var _ FieldParser = &tagBaseFieldParser{p: nil, field: nil, tag: ""}
+var _ FieldParser = (*tagBaseFieldParser)(nil)
 
 const (
 	requiredLabel    = "required"
@@ -187,6 +187,7 @@ type structField struct {
 	enums        []interface{}
 	enumVarNames []interface{}
 	unique       bool
+	pattern      string
 }
 
 // splitNotWrapped slices s into all substrings separated by sep if sep is not
@@ -573,6 +574,29 @@ func parseValidTags(validTag string, sf *structField) {
 	}
 }
 
+// enumValueEqual efficiently compares primitive types and falls back to reflect.DeepEqual for others.
+func enumValueEqual(a, b interface{}) bool {
+	switch va := a.(type) {
+	case string:
+		vb, ok := b.(string)
+		return ok && va == vb
+	case int:
+		vb, ok := b.(int)
+		return ok && va == vb
+	case int64:
+		vb, ok := b.(int64)
+		return ok && va == vb
+	case float64:
+		vb, ok := b.(float64)
+		return ok && va == vb
+	case bool:
+		vb, ok := b.(bool)
+		return ok && va == vb
+	default:
+		return reflect.DeepEqual(a, b)
+	}
+}
+
 func parseEnumTags(enumTag string, field *structField) error {
 	enumType := field.schemaType
 	if field.schemaType == ARRAY {
@@ -588,9 +612,9 @@ func parseEnumTags(enumTag string, field *structField) error {
 		}
 
 		for _, e := range field.enums {
-			if reflect.DeepEqual(e, value) {
+			if enumValueEqual(e, value) {
 				// skip duplicate enum value
-				return nil
+				continue
 			}
 		}
 

--- a/field_parser.go
+++ b/field_parser.go
@@ -187,7 +187,6 @@ type structField struct {
 	enums        []interface{}
 	enumVarNames []interface{}
 	unique       bool
-	pattern      string
 }
 
 // splitNotWrapped slices s into all substrings separated by sep if sep is not

--- a/field_parser.go
+++ b/field_parser.go
@@ -614,7 +614,7 @@ func parseEnumTags(enumTag string, field *structField) error {
 		for _, e := range field.enums {
 			if enumValueEqual(e, value) {
 				foundDuplicate = true
-				continue
+				break
 			}
 		}
 

--- a/field_parser_test.go
+++ b/field_parser_test.go
@@ -183,6 +183,21 @@ func TestDefaultFieldParser(t *testing.T) {
 		assert.Error(t, err)
 	})
 
+	t.Run("Duplicated enum values", func(t *testing.T) {
+		t.Parallel()
+
+		schema := spec.Schema{}
+		schema.Type = []string{"string"}
+		err := newTagBaseFieldParser(
+			&Parser{},
+			&ast.Field{Tag: &ast.BasicLit{
+				Value: `json:"test" enums:"a,b,c,c,c,c"`,
+			}},
+		).ComplementSchema(&schema)
+		assert.NoError(t, err)
+		assert.Equal(t, []interface{}{"a", "b", "c"}, schema.Enum)
+	})
+
 	t.Run("EnumVarNames tag", func(t *testing.T) {
 		t.Parallel()
 

--- a/field_parser_test.go
+++ b/field_parser_test.go
@@ -191,11 +191,11 @@ func TestDefaultFieldParser(t *testing.T) {
 		err := newTagBaseFieldParser(
 			&Parser{},
 			&ast.Field{Tag: &ast.BasicLit{
-				Value: `json:"test" enums:"a,b,c,c,c,c"`,
+				Value: `json:"test" enums:"a,b,c,c,c,c,d,e"`,
 			}},
 		).ComplementSchema(&schema)
 		assert.NoError(t, err)
-		assert.Equal(t, []interface{}{"a", "b", "c"}, schema.Enum)
+		assert.Equal(t, []interface{}{"a", "b", "c", "d", "e"}, schema.Enum)
 	})
 
 	t.Run("EnumVarNames tag", func(t *testing.T) {

--- a/gen/gen.go
+++ b/gen/gen.go
@@ -292,7 +292,7 @@ func processAsyncAPIChannels(asyncAPI *asyncSpec.AsyncAPI) error {
 		}
 
 		reflector.AddChannel(asyncReflector.ChannelInfo{
-			Name:           channelName,
+			Name:            channelName,
 			BaseChannelItem: &channel,
 		})
 	}

--- a/parser.go
+++ b/parser.go
@@ -1216,7 +1216,6 @@ func addAsyncAPIOperations(parser *Parser, asyncAPIScope *AsyncScope) {
 	}
 }
 
-
 func refRouteMethodOp(item *spec.PathItem, method string) (op **spec.Operation) {
 	switch method {
 	case http.MethodGet:

--- a/testdata/simple_async/api/api.go
+++ b/testdata/simple_async/api/api.go
@@ -1,8 +1,7 @@
 package api
 
-
 type MyMessage struct {
-	Message string
+	Message   string
 	MessageID int
 }
 

--- a/types.go
+++ b/types.go
@@ -11,10 +11,10 @@ import (
 
 // Schema parsed schema.
 type Schema struct {
-	*spec.Schema        //
-	PkgPath      string // package import path used to rename Name of a definition int case of conflict
-	Name         string // Name in definitions
-	UsedForOpenAPI bool
+	*spec.Schema           //
+	PkgPath         string // package import path used to rename Name of a definition int case of conflict
+	Name            string // Name in definitions
+	UsedForOpenAPI  bool
 	UsedForAsyncAPI bool
 }
 


### PR DESCRIPTION
This pull request adds logic to handle duplicate enum values during field parsing and introduces a corresponding test to ensure this behavior works correctly.

Enum parsing improvements:

* Updated the `parseEnumTags` function in `field_parser.go` to skip adding duplicate enum values to the `field.enums` slice.

Testing enhancements:

* Added a test case in `field_parser_test.go` to verify that duplicate enum values in tags are ignored and only unique values are included in the resulting schema.
