### PR TITLE
Forbid duplicated values for enums v2

### DIFF
--- a/field_parser.go
+++ b/field_parser.go
@@ -623,11 +623,17 @@ func parseEnumTags(enumTag string, field *structField) error {
 			return err
 		}
 
+		foundDuplicate := false
 		for _, e := range field.enums {
 			if enumValueEqual(e, value) {
 				// skip duplicate enum value
-				return nil
+				foundDuplicate = true
+				continue
 			}
+		}
+
+		if foundDuplicate {
+			continue
 		}
 
 		field.enums = append(field.enums, value)

--- a/field_parser.go
+++ b/field_parser.go
@@ -628,7 +628,7 @@ func parseEnumTags(enumTag string, field *structField) error {
 			if enumValueEqual(e, value) {
 				// skip duplicate enum value
 				foundDuplicate = true
-				continue
+				break
 			}
 		}
 

--- a/field_parser_test.go
+++ b/field_parser_test.go
@@ -191,11 +191,11 @@ func TestDefaultFieldParser(t *testing.T) {
 		err := newTagBaseFieldParser(
 			&Parser{},
 			&ast.Field{Tag: &ast.BasicLit{
-				Value: `json:"test" enums:"a,b,c,c,c,c"`,
+				Value: `json:"test" enums:"a,b,c,c,c,c,d,e"`,
 			}},
 		).ComplementSchema(&schema)
 		assert.NoError(t, err)
-		assert.Equal(t, []interface{}{"a", "b", "c"}, schema.Enum)
+		assert.Equal(t, []interface{}{"a", "b", "c", "d", "e"}, schema.Enum)
 	})
 
 	t.Run("EnumVarNames tag", func(t *testing.T) {


### PR DESCRIPTION
This pull request improves the handling of duplicate enum values in field parsing logic, ensuring that all unique values are preserved and only duplicates are skipped. The test coverage is also updated to reflect the new behavior.

### Enum Parsing Logic Improvements

* The `parseEnumTags` function in `field_parser.go` now skips only the duplicate enum values, allowing all unique values in the tag to be added to the field's enum list. Previously, encountering a duplicate would cause the function to return early and ignore subsequent unique values.

### Test Coverage Updates

* The test `TestDefaultFieldParser` in `field_parser_test.go` is updated to verify that all unique enum values are included, even if duplicates are present in the tag. The expected output now reflects the inclusion of all unique values.